### PR TITLE
Find matching history items in notebooks

### DIFF
--- a/bin/get
+++ b/bin/get
@@ -10,9 +10,13 @@ if __name__ == '__main__':
                         nargs='+',
                         help='The dataset ID/name from your Galaxy history, or a regex pattern to search all files in the history')
     parser.add_argument('-t', '--identifier_type', dest="identifier_type", choices=['hid', 'name', 'regex'], default='hid',
-                        help='Type of the argument File/ID Number. Per default, integer ID number. If a regex is used as the dataset ID/name, then this should be set to "regex"')
-    parser.add_argument('--history-id', dest="history_id", default=None, 
+                        help='Type of the argument File/ID Number. Per default, integer ID number. If a pattern is specified in -i argument, then this argument should be set to "regex"')
+    parser.add_argument('--history-id', dest="history_id", default=None,
                         help='History ID. The history ID and the dataset ID uniquly identify a dataset. Per default this is set to the current Galaxy history.')
     args = parser.parse_args()
 
-    print( get( args.id, args.identifier_type, args.history_id ) )
+    results = get( args.id, args.identifier_type, args.history_id )
+    if len(results) == 1:
+        print(results)
+    else:
+        print('\n'.join(results))

--- a/bin/get
+++ b/bin/get
@@ -8,9 +8,9 @@ if __name__ == '__main__':
     parser.add_argument('-i', '--id',
                         required = True,
                         nargs='+',
-                        help='The dataset ID/name from your Galaxy history.')
-    parser.add_argument('-t', '--identifier_type', dest="identifier_type", choices=['hid', 'name'], default='hid',
-                        help='Type of the argument File/ID Number. Per default, integer ID number.')
+                        help='The dataset ID/name from your Galaxy history, or a regex pattern to search all files in the history')
+    parser.add_argument('-t', '--identifier_type', dest="identifier_type", choices=['hid', 'name', 'regex'], default='hid',
+                        help='Type of the argument File/ID Number. Per default, integer ID number. If a regex is used as the dataset ID/name, then this should be set to "regex"')
     parser.add_argument('--history-id', dest="history_id", default=None, 
                         help='History ID. The history ID and the dataset ID uniquly identify a dataset. Per default this is set to the current Galaxy history.')
     args = parser.parse_args()

--- a/bin/get
+++ b/bin/get
@@ -10,7 +10,7 @@ if __name__ == '__main__':
                         nargs='+',
                         help='The dataset ID/name from your Galaxy history, or a regex pattern to search all files in the history')
     parser.add_argument('-t', '--identifier_type', dest="identifier_type", choices=['hid', 'name', 'regex'], default='hid',
-                        help='Type of the argument File/ID Number. Per default, integer ID number. If a pattern is specified in -i argument, then this argument should be set to "regex"')
+                        help='Type of the argument File/ID Number. Per default, integer ID number. If a pattern is specified in the -i argument, then this argument should be set to "regex"')
     parser.add_argument('--history-id', dest="history_id", default=None,
                         help='History ID. The history ID and the dataset ID uniquly identify a dataset. Per default this is set to the current Galaxy history.')
     args = parser.parse_args()

--- a/galaxy_ie_helpers/__init__.py
+++ b/galaxy_ie_helpers/__init__.py
@@ -153,7 +153,9 @@ def find_matching_history_ids(list_of_regex_patterns,
 def get(datasets_identifiers, identifier_type='hid', history_id=None):
     """
         Given the history_id that is displayed to the user, this function will
-        download the file[s] from the history and stores them under /import/
+        either search for matching files in the history if the identifier_type
+        is set to 'regex', otherwise it will directly download the file[s] from
+        the history and stores them under /import/.
         Return value[s] are the path[s] to the dataset[s] stored under /import/
     """
     history_id = history_id or os.environ['HISTORY_ID']
@@ -161,6 +163,11 @@ def get(datasets_identifiers, identifier_type='hid', history_id=None):
     # fallback to the non-object path
     gi = get_galaxy_connection(history_id=history_id, obj=False)
     file_path_all = []
+
+    if identifier_type == "regex":
+        datasets_identifiers = find_matching_history_ids(datasets_identifiers)
+        identifier_type = "hid"
+
     for dataset_identifier in datasets_identifiers:
         file_path = '/import/%s' % dataset_identifier
         log.debug('Downloading gx=%s history=%s dataset=%s', gi, history_id, dataset_identifier)

--- a/galaxy_ie_helpers/__init__.py
+++ b/galaxy_ie_helpers/__init__.py
@@ -146,7 +146,8 @@ def find_matching_history_ids(list_of_regex_patterns,
                 log.debug("Matched on history item %s (%s) : '%s' " % (fhid, fid, fname))
                 matching_ids.append(fhid if identifier_type == "hid" else fid)
 
-    return(matching_ids)
+    # unique only
+    return(list(set(matching_ids)))
 
 
 def get(datasets_identifiers, identifier_type='hid', history_id=None):

--- a/galaxy_ie_helpers/__init__.py
+++ b/galaxy_ie_helpers/__init__.py
@@ -123,6 +123,7 @@ def get(datasets_identifiers, identifier_type='hid', history_id=None):
     # The object version of bioblend is to slow in retrieving all datasets from a history
     # fallback to the non-object path
     gi = get_galaxy_connection(history_id=history_id, obj=False)
+    file_path_all = []
     for dataset_identifier in datasets_identifiers:
         file_path = '/import/%s' % dataset_identifier
         log.debug('Downloading gx=%s history=%s dataset=%s', gi, history_id, dataset_identifier)
@@ -140,13 +141,17 @@ def get(datasets_identifiers, identifier_type='hid', history_id=None):
         else:
             log.debug('Cached, not re-downloading')
 
-    return file_path
+        file_path_all.append(file_path)
+
+    ## First path if only one item given, otherwise all paths.
+    ## Should not break compatibility.
+    return file_path_all[0] if len(file_path_all) == 1 else file_path_all
 
 def get_user_history (history_id=None):
     """
        Get all visible dataset infos of user history.
        Return a list of dict of each dataset.
-    """ 
+    """
     history_id = history_id or os.environ['HISTORY_ID']
     gi = get_galaxy_connection(history_id=history_id, obj=False)
     hc = HistoryClient(gi)


### PR DESCRIPTION
Added `find_matching_history_ids` function which can be used to find datasets in a history matching regex pattern(s).  These can then be fed into the `get` function. This should allow notebooks to be more flexible in how they import data especially with respect to workflows.

@bgruening is this function automatically exported?
