### PR TITLE
Fix to get() for non-list ids

### DIFF
--- a/galaxy_ie_helpers/__init__.py
+++ b/galaxy_ie_helpers/__init__.py
@@ -168,6 +168,9 @@ def get(datasets_identifiers, identifier_type='hid', history_id=None):
         datasets_identifiers = find_matching_history_ids(datasets_identifiers)
         identifier_type = "hid"
 
+    if type(dataset_identifiers) is not list:
+        dataset_identifiers = [dataset_identifiers]
+
     for dataset_identifier in datasets_identifiers:
         file_path = '/import/%s' % dataset_identifier
         log.debug('Downloading gx=%s history=%s dataset=%s', gi, history_id, dataset_identifier)

--- a/galaxy_ie_helpers/__init__.py
+++ b/galaxy_ie_helpers/__init__.py
@@ -172,9 +172,9 @@ def get(datasets_identifiers, identifier_type='hid', history_id=None):
         identifier_type = "hid"
 
 
-    for dataset_identifier in datasets_identifiers:
-        file_path = '/import/%s' % dataset_identifier
-        log.debug('Downloading gx=%s history=%s dataset=%s', gi, history_id, dataset_identifier)
+    for dataset_id in datasets_identifiers:
+        file_path = '/import/%s' % dataset_id
+        log.debug('Downloading gx=%s history=%s dataset=%s', gi, history_id, dataset_id)
         # Cache the file requests. E.g. in the example of someone doing something
         # silly like a get() for a Galaxy file in a for-loop, wouldn't want to
         # re-download every time and add that overhead.
@@ -184,8 +184,8 @@ def get(datasets_identifiers, identifier_type='hid', history_id=None):
             history = hc.show_history(history_id, contents=True)
             datasets = {ds[identifier_type]: ds['id'] for ds in history}
             if identifier_type == 'hid':
-                dataset_identifier = int(dataset_identifier)
-            dc.download_dataset(datasets[dataset_identifier], file_path=file_path, use_default_filename=False)
+                dataset_id = int(dataset_id)
+            dc.download_dataset(datasets[dataset_id], file_path=file_path, use_default_filename=False)
         else:
             log.debug('Cached, not re-downloading')
 

--- a/galaxy_ie_helpers/__init__.py
+++ b/galaxy_ie_helpers/__init__.py
@@ -164,12 +164,13 @@ def get(datasets_identifiers, identifier_type='hid', history_id=None):
     gi = get_galaxy_connection(history_id=history_id, obj=False)
     file_path_all = []
 
+    if type(datasets_identifiers) is not list:
+        datasets_identifiers = [datasets_identifiers]
+
     if identifier_type == "regex":
         datasets_identifiers = find_matching_history_ids(datasets_identifiers)
         identifier_type = "hid"
 
-    if type(dataset_identifiers) is not list:
-        dataset_identifiers = [dataset_identifiers]
 
     for dataset_identifier in datasets_identifiers:
         file_path = '/import/%s' % dataset_identifier


### PR DESCRIPTION
Appears to work with the following

```
conda create -n gie pip
pip install git+https://github.com/mtekman/galaxy_ie_helpers.git
GALAXY_URL=https://usegalaxy.eu 
HISTORY_ID=424b38f7b103b91f 
API_KEY=[blah]
python
>>> get(1)
'/import/1'
>>> get([1])
'/import/1'
>>> get('.*annotation.*', identifier_type='regex')
['/import/3', '/import/7']
>>> get([1,3,7])
['/import/1', '/import/3', '/import/7']
```